### PR TITLE
Simplify options and enable data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,36 @@ npm install tippy-remote-plugin
 ```
 
 ## Usage
+### With options
 ```html
-<a href="#" id="remote">My popover</a>
+<a href="#" id="remote">My link</a>
 ```
 
 ```js
+import tippy from 'tippy.js';
 import remote from 'tippy-remote-plugin'
 
 tippy('#remote', {
   plugins: [remote],
-  remote: {
-    url: 'my-remote-content.html'
-  }
+  remote: '/remote-url.html'
 })
 ```
 
-## Options
-| Name | Value    | Default     | Description                    |
-| ---- | -------- | ----------- | ------------------------------ |
-| url  | `string` | `undefined` | The URL to get remote content. |
+#### Options
+| Name   | Value               | Default | Description                    |
+| ------ | ------------------- | ------- | ------------------------------ |
+| remote | `string` \| `false` | `false` | The URL to get remote content. |
+
+### With data attributes
+```html
+<a href="#" data-tippy-remote="/remote-url.html">My link</a>
+```
+
+```js
+import tippy from 'tippy.js';
+import remote from 'tippy-remote-plugin'
+
+tippy('[data-tippy-remote]', {
+  plugins: [remote]
+})
+```

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,21 +19,18 @@
   </style>
 </head>
 <body>
-  <a href="https://github.com/ocarreterom" class="remote-content" target="_blank">@ocarreterom</a>
-  <a href="https://github.com/ocarreterom" class="remote-content" target="_blank">@ocarreterom</a>
+  <a href="https://github.com/ocarreterom" data-tippy-remote="./partial-content.html" target="_blank">@ocarreterom</a>
+  <a href="https://github.com/ocarreterom" data-tippy-remote="./partial-content.html" target="_blank">@ocarreterom</a>
 
   <script type="module">
     // import remote from '../dist/index.js'
     import remote from 'https://unpkg.com/tippy-remote-plugin@latest'
 
-    tippy('.remote-content', {
+    tippy('[data-tippy-remote]', {
       flipOnUpdate: true,
       interactive: true,
       placement: 'bottom-start',
       plugins: [remote],
-      remote: {
-        url: './partial-content.html'
-      },
       theme: 'light-border'
     })
   </script>

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 const cache = new Map()
 
-const remote = {
+const plugin = {
   name: 'remote',
-  defaultValue: {},
+  defaultValue: false,
 
   fn(instance) {
     const {state} = instance
-    const {remote} = instance.props
 
     return {
       onCreate() {
@@ -17,10 +16,10 @@ const remote = {
       onTrigger() {
         if (state.isLoaded || state.isLoading) return
 
-        const {url} = remote
-        if (!url) return
+        const src = instance.props.remote
+        if (!src) return
 
-        const {content} = cache.get(url) || {}
+        const {content} = cache.get(src) || {}
         if (content) {
           instance.setContent(content)
           return
@@ -28,12 +27,12 @@ const remote = {
 
         state.isLoading = true
 
-        fetch(url)
+        fetch(src)
           .then(response => response.text())
           .then(content => {
             instance.setContent(content)
             state.isLoaded = true
-            cache.set(url, {content})
+            cache.set(src, {content})
           })
           .catch(() => {
             state.isLoaded = false
@@ -46,4 +45,4 @@ const remote = {
   }
 }
 
-export default remote
+export default plugin


### PR DESCRIPTION
Change options structure.
Before:
```js
tippy(element, {
  plugins: [remote],
  remote: {
    url: '/content.html'
  }
})
```
After:
```js
tippy(element, {
  plugins: [remote],
  remote: '/content.html'
})
```
And enable setting the url with data attributes.
```html
<a href="#" data-tippy-remote="/content.html">My link</a>
```